### PR TITLE
chore: rename dir to align with transport later

### DIFF
--- a/api/route/donate/donate.go
+++ b/api/route/donate/donate.go
@@ -1,11 +1,11 @@
 package donate
 
 import (
-	"github.com/arvinpaundra/cent/payment/application/resthttp"
+	"github.com/arvinpaundra/cent/payment/application/rest"
 	"github.com/gin-gonic/gin"
 )
 
-func PublicRoute(g *gin.RouterGroup, cont resthttp.Controller) {
+func PublicRoute(g *gin.RouterGroup, cont rest.Controller) {
 	donate := g.Group("/donate")
 
 	donate.POST("", cont.CreateDonation)

--- a/api/route/routes.go
+++ b/api/route/routes.go
@@ -3,7 +3,7 @@ package route
 import (
 	"github.com/arvinpaundra/cent/payment/api/middleware"
 	"github.com/arvinpaundra/cent/payment/api/route/donate"
-	"github.com/arvinpaundra/cent/payment/application/resthttp"
+	"github.com/arvinpaundra/cent/payment/application/rest"
 	"github.com/arvinpaundra/cent/payment/core/validator"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -13,11 +13,11 @@ type Routes struct {
 	g    *gin.Engine
 	db   *gorm.DB
 	vld  *validator.Validator
-	cont resthttp.Controller
+	cont rest.Controller
 }
 
 func NewRoutes(g *gin.Engine, db *gorm.DB, vld *validator.Validator) *Routes {
-	controller := resthttp.NewController(db, vld)
+	controller := rest.NewController(db, vld)
 
 	g.Use(middleware.Cors())
 	g.Use(gin.Recovery())

--- a/application/rest/controller.go
+++ b/application/rest/controller.go
@@ -1,4 +1,4 @@
-package resthttp
+package rest
 
 import (
 	"github.com/arvinpaundra/cent/payment/core/validator"

--- a/application/rest/payment.go
+++ b/application/rest/payment.go
@@ -1,4 +1,4 @@
-package resthttp
+package rest
 
 import (
 	"net/http"

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -62,7 +62,7 @@ var restCmd = &cobra.Command{
 			"postgres": func(_ context.Context) error {
 				return pgsql.Close()
 			},
-			"grpc-client": func(ctx context.Context) error {
+			"grpc-client": func(_ context.Context) error {
 				return grpcClient.Close()
 			},
 		})


### PR DESCRIPTION
This pull request primarily focuses on renaming the `resthttp` package to `rest` across the codebase for improved clarity and consistency. Additionally, it includes minor adjustments to method signatures and variable usage. Below is a summary of the most important changes:

### Package Renaming

* Renamed the `resthttp` package to `rest` in all relevant files, including `application/rest/controller.go` (formerly `application/resthttp/controller.go`) and `application/rest/payment.go` (formerly `application/resthttp/payment.go`). [[1]](diffhunk://#diff-1e6b07757819640995da980e8dd56fe0893b1e514ef0418f2da31ae5ef7871e5L4-R8) [[2]](diffhunk://#diff-3f3779bd69d9c854a922993f44c39fa950b8dd8a40ab35c3c1d678975fdd9daaL1-R1) [[3]](diffhunk://#diff-b0de2158e681f23a48d2ccb63330c35a700d37884f3191522f20ab98b5e60c6cL1-R1)

### Code Adjustments for Renaming

* Updated imports in `api/route/donate/donate.go` and `api/route/routes.go` to use the renamed `rest` package. [[1]](diffhunk://#diff-1e6b07757819640995da980e8dd56fe0893b1e514ef0418f2da31ae5ef7871e5L4-R8) [[2]](diffhunk://#diff-21405742872cc12279e7003b0bb90b8ee29e6f0acf3fe5130c8eeabbd94e0175L6-R6)
* Modified the `Routes` struct and its initialization in `api/route/routes.go` to reflect the renamed `rest.Controller`.

### Minor Code Improvements

* Simplified the `grpc-client` cleanup function in `cmd/rest.go` by removing the unused `ctx` parameter.